### PR TITLE
:arrow_up: (pg-format) 4.4->5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,10 +72,10 @@
   },
   "scripts": {
     "build": "rm -fr ./dist && babel ./src --out-dir ./dist --copy-files --source-maps",
-    "build-pg-formatter": "rm -fr ./src/pg-formatter && mkdir -p ./src/pg-formatter && curl -LkSs https://github.com/darold/pgFormatter/archive/refs/tags/v4.4.tar.gz | tar xz --strip-components=1 -C ./src/pg-formatter",
+    "build-pg-formatter": "rm -fr ./src/pg-formatter && mkdir -p ./src/pg-formatter && curl -LkSs https://github.com/darold/pgFormatter/archive/refs/tags/v5.5.tar.gz | tar xz --strip-components=1 -C ./src/pg-formatter",
     "lint": "eslint ./src ./test && flow",
     "test": "ava --serial --verbose"
   },
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
for fixing https://github.com/darold/pgFormatter/commit/a6c080c05f69f879cabfe634755a429683e3b648

```
> pg-formatter@1.0.2 test
> ava --serial --verbose


  - {functionCase: unchanged} custom function
  - {functionCase: unchanged} custom function with parameters
  ✔ formats SQL
  ✔ {anonymize: true}
  ✔ {stripComments: true} block comment
  ✔ {stripComments: true} inline comment
  ✔ {functionCase: unchanged}
  ✔ {functionCase: uppercase}
  ✔ {functionCase: lowercase}
  ✔ {functionCase: capitalize}
  ✔ {keywordCase: unchanged}
  ✔ {keywordCase: uppercase}
  ✔ {keywordCase: lowercase}
  ✔ {keywordCase: capitalize}
  ✔ {spaces: 2}
  ✔ {tabs: true}
  ✔ {placeholder: <<(?:.*)?>>}
  ✔ {noRcFile: true}
  ✔ {commaBreak: true}

  17 tests passed
  2 tests skipped
```