### PR TITLE
docs: fix missed comma-break in programmatically usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ format(`SELECT foo FROM bar`);
 |Configuration|Format|Default|Description|`pgFormatter` equivalent|
 |---|---|---|---|---|
 |`anonymize`|boolean|`false`|Obscure all literals in queries, useful to hide confidential data before formatting.|`anonymize`|
+|`commaBreak`|boolean|`false`|Add a newline after each comma in an insert statement.|`comma-break`|
 |`functionCase`|string ("unchanged", "lowercase", "uppercase", "capitalize")|`unchanged`|Change the case of the function names.|`function-case`|
 |`keywordCase`|string ("unchanged", "lowercase", "uppercase", "capitalize")|`unchanged`|Change the case of the reserved keyword.|`keyword-case`|
 |`noRcFile`|boolean|`false`|Do not read ~/.pg_format automatically.|`no-rcfile`|


### PR DESCRIPTION
closes: #26 