### PR TITLE
Inherit the system's locale

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -118,9 +118,6 @@ export const format = (
     [executablePath, ...args.flat()],
     {
       encoding: 'utf8',
-      env: {
-        LC_ALL: 'C.UTF-8',
-      },
       input: sql,
     },
   );


### PR DESCRIPTION
It is safe to run the `pg_format` executable without hard-coding the locale.

Fixes #34